### PR TITLE
hotfix: could not insert result block due to missing check in result field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr
 Title: A block-based framework for data manipulation and visualization
-Version: 0.0.2.9030
+Version: 0.0.2.9031
 Authors@R: 
     c(person(given = "Nicolas",
              family = "Bennett",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# blockr 0.0.2.9030
+# blockr 0.0.2.9031
 
 ## Feature
 - Improved `submit` feature for blocks. Now submit isn't added as a class but as a special block attribute. When you design a block, you can pass the `submit` parameter like so:

--- a/R/server.R
+++ b/R/server.R
@@ -17,6 +17,7 @@ generate_server.result_field <- function(x, ...) {
   function(id, init = NULL, data = NULL) {
     moduleServer(id, function(input, output, session) {
       get_result <- function(inp) {
+        req(inp)
         res <- get_stack_result(
           get_workspace_stack(inp)
         )

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -206,6 +206,6 @@ reference:
 
 news:
  releases:
- - text: "blockr 0.0.2.9023"
+ - text: "blockr 0.0.2.9031"
  - text: "blockr 0.0.2"
  - text: "blockr 0.0.1.9000"


### PR DESCRIPTION
@nbenn As discussed, fixing an issue where we could pass NULL to `get_workspace_stack`, leading to an error in `is_string`.

- Bumped version from 0.0.2.9030 to 0.0.2.9031