### PR TITLE
Forward plugins through run_app() to serve()

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -20,13 +20,16 @@
 #' @rdname run_app
 #' @export
 run_app <- function(..., extensions = new_dag_extension(),
-                    id = rand_names()) {
+                    plugins = blockr_app_plugins,
+                    options = blockr_app_options, id = rand_names()) {
 
-  prev <- options(g6R.layout_on_data_change = TRUE)
-  on.exit(do.call(options, prev))
+  prev <- base::options(g6R.layout_on_data_change = TRUE)
+  on.exit(do.call(base::options, prev))
 
   serve(
     new_dock_board(..., extensions = extensions),
-    id = id
+    id = id,
+    plugins = plugins,
+    options = options
   )
 }

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -4,10 +4,20 @@
 \alias{run_app}
 \title{Run app}
 \usage{
-run_app(..., extensions = new_dag_extension(), id = rand_names())
+run_app(
+  ...,
+  extensions = new_dag_extension(),
+  plugins = blockr_app_plugins,
+  options = blockr_app_options,
+  id = rand_names()
+)
 }
 \arguments{
 \item{..., extensions}{Forwarded to \code{\link[blockr.dock:dock]{blockr.dock::new_dock_board()}}}
+
+\item{plugins}{Board plugins}
+
+\item{options}{Board options}
 
 \item{id}{Board namespace ID}
 }

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1,3 +1,25 @@
+test_that("run_app forwards plugins and options to serve", {
+
+  served <- NULL
+  local_mocked_bindings(
+    serve = function(x, ...) {
+      served <<- list(...)
+      invisible(x)
+    }
+  )
+
+  custom_plg <- custom_plugins(list())
+  custom_opt <- custom_options(list())
+
+  run_app(plugins = custom_plg, options = custom_opt)
+  expect_identical(served$plugins, custom_plg)
+  expect_identical(served$options, custom_opt)
+
+  run_app()
+  expect_identical(served$plugins, blockr_app_plugins)
+  expect_identical(served$options, blockr_app_options)
+})
+
 test_that("merge app", {
 
   skip_on_cran()


### PR DESCRIPTION
## Summary

- `run_app()` passed only `id` on to `serve()`, swallowing `plugins` and `options` into `...` (where they reached `new_dock_board()` instead). Both are now explicit formals forwarded to `serve()`, each defaulting to serve's own `blockr_app_plugins` / `blockr_app_options`, so no-argument behaviour is unchanged.
- This exposes serve's customization pair through the meta-package entry point: `run_app(plugins = custom_plugins(…), options = custom_options(…))`. Board-option *values* stay reachable via `custom_options()` — the serve-level parallel to `custom_plugins()` — so routing `options` to `serve()` rather than `new_dock_board()` loses nothing; only the raw `run_app(options = <board_options>)` constructor path changes, which is fine in a forward-only ecosystem.
- The `options` formal is referenced as `base::options()` in the body, so the option-setting call there still hits the base function rather than the new formal.

Companion to BristolMyersSquibb/blockr.uat#2, whose app needs `run_app(plugins = custom_plugins(manage_project()))`. That repo pins `blockr` to this branch until this merges, then flips the pin to main.