### PR TITLE
Forward plugins through run_app() to serve()

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -20,13 +20,14 @@
 #' @rdname run_app
 #' @export
 run_app <- function(..., extensions = new_dag_extension(),
-                    id = rand_names()) {
+                    plugins = blockr_app_plugins, id = rand_names()) {
 
   prev <- options(g6R.layout_on_data_change = TRUE)
   on.exit(do.call(options, prev))
 
   serve(
     new_dock_board(..., extensions = extensions),
-    id = id
+    id = id,
+    plugins = plugins
   )
 }

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -4,10 +4,17 @@
 \alias{run_app}
 \title{Run app}
 \usage{
-run_app(..., extensions = new_dag_extension(), id = rand_names())
+run_app(
+  ...,
+  extensions = new_dag_extension(),
+  plugins = blockr_app_plugins,
+  id = rand_names()
+)
 }
 \arguments{
 \item{..., extensions}{Forwarded to \code{\link[blockr.dock:dock]{blockr.dock::new_dock_board()}}}
+
+\item{plugins}{Board plugins}
 
 \item{id}{Board namespace ID}
 }

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1,3 +1,40 @@
+test_that("run_app forwards plugins to serve", {
+
+  served <- NULL
+  local_mocked_bindings(
+    serve = function(x, ...) {
+      served <<- list(...)
+      invisible(x)
+    }
+  )
+
+  custom_plg <- custom_plugins(list())
+
+  run_app(plugins = custom_plg)
+  expect_identical(served$plugins, custom_plg)
+
+  run_app()
+  expect_identical(served$plugins, blockr_app_plugins)
+})
+
+test_that("run_app routes options to the board, not serve", {
+
+  served <- NULL
+  local_mocked_bindings(
+    serve = function(x, ...) {
+      served <<- list(board = x, args = list(...))
+      invisible(x)
+    }
+  )
+
+  opts <- new_board_options(new_board_name_option("from_run_app"))
+
+  run_app(options = opts)
+
+  expect_false("options" %in% names(served$args))
+  expect_identical(board_options(served$board), opts)
+})
+
 test_that("merge app", {
 
   skip_on_cran()


### PR DESCRIPTION
## Summary

- `run_app()` swallowed `plugins` into `...`, where it reached `new_dock_board()` (which has no `plugins` argument) instead of `serve()` — so there was no way to hand `serve()` a custom plugin set such as `custom_plugins(manage_project())`. `plugins` is now an explicit formal forwarded to `serve()`, defaulting to `blockr_app_plugins` so the no-argument behaviour is unchanged.
- `options` is deliberately **not** forwarded to `serve()`. It stays routed through `...` to `new_dock_board()` as board-option *values*, which serve's own default resolver (`blockr_app_options.dock_board()`) already reads back via `board_options()`. This keeps `run_app(options = <values>)` working as before and avoids an `options` formal shadowing `base::options()` inside the body.

Supersedes #482, which forwarded both `plugins` and `options` to `serve()`. Forwarding `options` there is the wrong layer: `serve(options = )` is a *resolver function*, not values, so it broke the `run_app(options = <values>)` → `new_dock_board()` path, forced a `custom_options()` wrapper, and introduced the `base::options()` shadow. Plugins live only at serve; option values live on the board — the asymmetry is the correct shape.

Fixes #483
